### PR TITLE
Support for Jackson v2.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 Rison Parser and Generator for Jackson
 ======================================
 
-A plugin for the [Jackson streaming JSON processor v2.1.x] (http://wiki.fasterxml.com/JacksonHome) that adds
+A plugin for the [Jackson streaming JSON processor v2.0.x] (http://wiki.fasterxml.com/JacksonHome) that adds
 support for reading and writing JSON objects in the [Rison] (http://mjtemplate.org/examples/rison.html)
-serialization format.
+serialization format.  Support for Jackson [v1.9.x] (https://github.com/bazaarvoice/rison/tree/rison-1.2) is
+also available.
 
 Rison expresses the exact same data structures as JSON, but is much more compact and readable than JSON
 when encoded in a URI.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.bazaarvoice.jackson</groupId>
     <artifactId>rison</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Rison data format</name>
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.1.2</jackson.version>
+        <jackson.version>2.0.6</jackson.version>
     </properties>
 
     <dependencies>
@@ -52,6 +52,15 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <!-- Enable filtering to inject version into VERSION.txt. -->
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 
     <distributionManagement>
         <repository>

--- a/src/main/java/com/bazaarvoice/jackson/rison/ModuleVersion.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/ModuleVersion.java
@@ -1,0 +1,7 @@
+package com.bazaarvoice.jackson.rison;
+
+import com.fasterxml.jackson.core.util.VersionUtil;
+
+public class ModuleVersion extends VersionUtil {
+    public final static ModuleVersion instance = new ModuleVersion();
+}

--- a/src/main/java/com/bazaarvoice/jackson/rison/RisonFactory.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/RisonFactory.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.format.InputAccessor;
 import com.fasterxml.jackson.core.format.MatchStrength;
 import com.fasterxml.jackson.core.io.IOContext;
@@ -17,7 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 
@@ -52,6 +52,11 @@ public class RisonFactory extends JsonFactory {
     @Override
     public MatchStrength hasFormat(InputAccessor acc) throws IOException {
         return MatchStrength.SOLID_MATCH;  // format detection isn't supported
+    }
+
+    @Override
+    public Version version() {
+        return ModuleVersion.instance.version();
     }
 
     //
@@ -113,15 +118,15 @@ public class RisonFactory extends JsonFactory {
     //
 
     @Override
+    protected RisonParser _createJsonParser(InputStream in, IOContext ctxt) throws IOException, JsonParseException {
+        return _createJsonParser(new InputStreamReader(in, "UTF-8"), ctxt);
+    }
+
+    @Override
     protected RisonParser _createJsonParser(Reader r, IOContext ctxt) throws IOException, JsonParseException {
         return new RisonParser(ctxt, _parserFeatures, _risonParserFeatures, r, _objectCodec,
                 _rootCharSymbols.makeChild(isEnabled(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES),
                         isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES)));
-    }
-
-    @Override
-    protected RisonParser _createJsonParser(InputStream in, IOContext ctxt) throws IOException, JsonParseException {
-        return _createJsonParser(new InputStreamReader(in, "UTF-8"), ctxt);
     }
 
     @Override
@@ -137,18 +142,5 @@ public class RisonFactory extends JsonFactory {
     @Override
     protected RisonGenerator _createUTF8JsonGenerator(OutputStream out, IOContext ctxt) throws IOException {
         return _createJsonGenerator(_createWriter(out, JsonEncoding.UTF8, ctxt), ctxt);
-    }
-
-    @Override
-    protected Writer _createWriter(OutputStream out, JsonEncoding enc, IOContext ctxt) throws IOException {
-        // For better performance, Jackson implements two JSON parsers and two JSON generators: one for byte streams
-        // (UTF8Writer and UTF8Generator) and one for character streams (WriterBasedGenerator and ReaderBasedParser).
-        // For Rison, the primary use case is parsing URL query parameters which must be run through a URL decoder
-        // (eg. java.net.URLEncoder) which handles % decoding and UTF-8 decoding and returns a String.  Since the
-        // result has already gone through UTF-8 decoding and turned into a character stream, there's not much of a
-        // use case for a byte stream-specific Rison parser or generator, so we haven't written one.  For completeness,
-        // if asked to parse a byte stream, just wrap it in an OutputStreamWriter and use the character stream impl.
-        // It might be a bit slower than a dedicated UTF8Writer-style Rison generator, but hopefully not a big deal.
-        return new OutputStreamWriter(out, enc.getJavaName());
     }
 }

--- a/src/main/java/com/bazaarvoice/jackson/rison/RisonGenerator.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/RisonGenerator.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.base.GeneratorBase;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.io.NumberOutput;
@@ -140,6 +141,11 @@ public final class RisonGenerator
         _outputEnd = _outputBuffer.length;
     }
 
+    @Override
+    public Version version() {
+        return ModuleVersion.instance.version();
+    }
+
     /*
    /**********************************************************
    /* Overridden configuration methods
@@ -161,12 +167,8 @@ public final class RisonGenerator
    /**********************************************************
     */
 
-    /* Most overrides in this section are just to make methods final,
-     * to allow better inlining...
-     */
-
     @Override
-    public final void writeFieldName(String name)  throws IOException, JsonGenerationException
+    public void writeFieldName(String name)  throws IOException, JsonGenerationException
     {
         int status = _writeContext.writeFieldName(name);
         if (status == JsonWriteContext.STATUS_EXPECT_VALUE) {
@@ -176,7 +178,7 @@ public final class RisonGenerator
     }
 
     @Override
-    public final void writeFieldName(SerializableString name)
+    public void writeFieldName(SerializableString name)
             throws IOException, JsonGenerationException
     {
         // Object is a value, need to verify it's allowed
@@ -202,7 +204,7 @@ public final class RisonGenerator
     }
 
     @Override
-    public final void writeStartArray() throws IOException, JsonGenerationException
+    public void writeStartArray() throws IOException, JsonGenerationException
     {
         _verifyValueWrite("start an array");
         if (!omitArrayWrappers(_writeContext)) {
@@ -216,7 +218,7 @@ public final class RisonGenerator
     }
 
     @Override
-    public final void writeEndArray() throws IOException, JsonGenerationException
+    public void writeEndArray() throws IOException, JsonGenerationException
     {
         if (!_writeContext.inArray()) {
             _reportError("Current context not an ARRAY but "+_writeContext.getTypeDesc());
@@ -231,7 +233,7 @@ public final class RisonGenerator
     }
 
     @Override
-    public final void writeStartObject() throws IOException, JsonGenerationException
+    public void writeStartObject() throws IOException, JsonGenerationException
     {
         _verifyValueWrite("start an object");
         if (!(omitObjectWrappers(_writeContext))) {
@@ -244,7 +246,7 @@ public final class RisonGenerator
     }
 
     @Override
-    public final void writeEndObject() throws IOException, JsonGenerationException
+    public void writeEndObject() throws IOException, JsonGenerationException
     {
         if (!_writeContext.inObject()) {
             _reportError("Current context not an object but "+_writeContext.getTypeDesc());
@@ -288,7 +290,7 @@ public final class RisonGenerator
     public void _writeFieldName(SerializableString name, boolean commaBefore)
             throws IOException, JsonGenerationException
     {
-        // can't take advantage of SerializableString.asQuotedChars() because JSON and Rison
+        // Can't take advantage of SerializableString.asQuotedChars() because JSON and Rison
         // have different rules for quoting characters within strings.
         _writeFieldName(name.getValue(), commaBefore);
     }
@@ -350,10 +352,10 @@ public final class RisonGenerator
     }
 
     @Override
-    public final void writeString(SerializableString sstr)
+    public void writeString(SerializableString sstr)
             throws IOException, JsonGenerationException
     {
-        // can't take advantage of SerializableString.asQuotedChars() because JSON and Rison
+        // Can't take advantage of SerializableString.asQuotedChars() because JSON and Rison
         // have different rules for quoting characters within strings.
         writeString(sstr.getValue());
     }
@@ -637,7 +639,7 @@ public final class RisonGenerator
      */
 
     @Override
-    public final void flush()
+    public void flush()
             throws IOException
     {
         _flushBuffer();

--- a/src/main/java/com/bazaarvoice/jackson/rison/RisonParser.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/RisonParser.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.base.ParserBase;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.sym.CharsToNameCanonicalizer;
@@ -141,6 +142,11 @@ public class RisonParser
         _symbols = st;
     }
 
+    @Override
+    public Version version() {
+        return ModuleVersion.instance.version();
+    }
+
     /*
     /**********************************************************
     /* Configuration
@@ -186,7 +192,7 @@ public class RisonParser
     }
 
     @Override
-    protected final boolean loadMore() throws IOException
+    protected boolean loadMore() throws IOException
     {
         _currInputProcessed += _inputEnd;
         _currInputRowStart -= _inputEnd;
@@ -268,7 +274,7 @@ public class RisonParser
      * Method can be called for any event.
      */
     @Override
-    public final String getText()
+    public String getText()
             throws IOException, JsonParseException
     {
         JsonToken t = _currToken;
@@ -282,7 +288,7 @@ public class RisonParser
         return _getText2(t);
     }
 
-    protected final String _getText2(JsonToken t)
+    protected String _getText2(JsonToken t)
     {
         if (t == null) {
             return null;
@@ -768,7 +774,7 @@ public class RisonParser
      * deferred, since it is usually the most complicated and costliest
      * part of processing.
      */
-    protected final JsonToken parseNumberText(int ch)
+    protected JsonToken parseNumberText(int ch)
             throws IOException, JsonParseException
     {
         /* Although we will always be complete with respect to textual
@@ -1087,7 +1093,7 @@ public class RisonParser
     /**********************************************************
      */
 
-    protected final String _parseFieldName(int i)
+    protected String _parseFieldName(int i)
             throws IOException, JsonParseException
     {
         /* First: let's try to see if we have a simple name: one that does
@@ -1167,10 +1173,8 @@ public class RisonParser
      * than double quote, when expecting a field name.
      * In standard mode will just throw an expection; but
      * in non-standard modes may be able to parse name.
-     *
-     * @since 1.2
      */
-    protected final String _parseUnquotedFieldName(int i)
+    protected String _parseUnquotedFieldName(int i)
             throws IOException, JsonParseException
     {
         // Also: first char must be a valid name char, but NOT be number
@@ -1202,10 +1206,8 @@ public class RisonParser
     /**
      * Method for handling cases where first non-space character
      * of an expected value token is not legal for standard JSON content.
-     *
-     * @since 1.3
      */
-    protected final JsonToken _handleUnexpectedValue(int i)
+    protected JsonToken _handleUnexpectedValue(int i)
             throws IOException, JsonParseException
     {
         // Most likely an error, unless we are to allow single-quote-strings
@@ -1229,9 +1231,6 @@ public class RisonParser
         return null;
     }
 
-    /**
-     * @since 1.2
-     */
     private String _parseUnquotedFieldName2(int startPtr, int hash)
             throws IOException, JsonParseException
     {
@@ -1452,7 +1451,7 @@ public class RisonParser
     }
 
     @Override
-    protected final char _decodeEscaped()
+    protected char _decodeEscaped()
             throws IOException, JsonParseException
     {
         if (_inputPtr >= _inputEnd) {
@@ -1469,10 +1468,8 @@ public class RisonParser
 
     /**
      * Helper method for checking whether input matches expected token
-     *
-     * @since 1.8
      */
-    protected final void _matchToken(String matchStr, int i)
+    protected void _matchToken(String matchStr, int i)
             throws IOException, JsonParseException
     {
         final int len = matchStr.length();

--- a/src/main/resources/com/bazaarvoice/jackson/rison/VERSION.txt
+++ b/src/main/resources/com/bazaarvoice/jackson/rison/VERSION.txt
@@ -1,0 +1,3 @@
+${project.version}
+${project.groupId}
+${project.artifactId}

--- a/src/test/java/com/bazaarvoice/jackson/rison/VersionTest.java
+++ b/src/test/java/com/bazaarvoice/jackson/rison/VersionTest.java
@@ -1,0 +1,30 @@
+package com.bazaarvoice.jackson.rison;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.Versioned;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class VersionTest {
+    @Test
+    public void testMapperVersions() throws IOException {
+        RisonFactory factory = new RisonFactory();
+        assertVersion(factory);
+        assertVersion(factory.createJsonGenerator(new ByteArrayOutputStream()));
+        assertVersion(factory.createJsonParser(new byte[0]));
+    }
+
+    private void assertVersion(Versioned versioned) {
+        Version version = versioned.version();
+        assertFalse(version.isUknownVersion(), "Should find version information (got " + version + ")");
+        assertEquals(version.getMajorVersion(), 2);
+        assertEquals(version.getMinorVersion(), 0);
+        assertEquals(version.getGroupId(), "com.bazaarvoice.jackson");
+        assertEquals(version.getArtifactId(), "rison");
+    }
+}


### PR DESCRIPTION
Release a version of the Rison parser that depends on Jackson v2.0.x, in case someone needs it.

Most of the changes are cosmetic.  The only real functional change is the implementation of the `Versioned` interface.
