### PR TITLE
Update RisonFactory for feature parity with Jackson 2.1.x JsonFactory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Rison Parser and Generator for Jackson
 ======================================
 
-A plugin for the [Jackson streaming JSON processor v2.0.x] (http://wiki.fasterxml.com/JacksonHome) that adds
+A plugin for the [Jackson streaming JSON processor v2.1.x] (http://wiki.fasterxml.com/JacksonHome) that adds
 support for reading and writing JSON objects in the [Rison] (http://mjtemplate.org/examples/rison.html)
-serialization format.  Support for Jackson [v1.9.x] (https://github.com/bazaarvoice/rison/tree/rison-1.2) is
-also available.
+serialization format.  Support for Jackson [v2.0.x] (https://github.com/bazaarvoice/rison/tree/rison-2.0.1)
+and [v1.9.x] (https://github.com/bazaarvoice/rison/tree/rison-1.2) is also available.
 
 Rison expresses the exact same data structures as JSON, but is much more compact and readable than JSON
 when encoded in a URI.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.bazaarvoice.jackson</groupId>
     <artifactId>rison</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Rison data format</name>
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.0.6</jackson.version>
+        <jackson.version>2.1.3</jackson.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/bazaarvoice/jackson/rison/RisonGenerator.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/RisonGenerator.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.base.GeneratorBase;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.io.NumberOutput;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -95,6 +96,9 @@ public final class RisonGenerator
 
     final protected int _risonFeatures;
 
+    protected SerializableString _rootValueSeparator
+            = DefaultPrettyPrinter.DEFAULT_ROOT_VALUE_SEPARATOR;
+
     /*
     /**********************************************************
     /* Output buffering
@@ -159,6 +163,12 @@ public final class RisonGenerator
 
     private boolean isRisonEnabled(Feature feature) {
         return (_risonFeatures & feature.getMask()) != 0;
+    }
+
+    @Override
+    public JsonGenerator setRootValueSeparator(SerializableString sep) {
+        _rootValueSeparator = sep;
+        return this;
     }
 
     /*
@@ -620,8 +630,10 @@ public final class RisonGenerator
                 c = ':';
                 break;
             case JsonWriteContext.STATUS_OK_AFTER_SPACE:
-                c = ' ';
-                break;
+                if (_rootValueSeparator != null) {
+                    _writeRaw(_rootValueSeparator.getValue());
+                }
+                return;
             case JsonWriteContext.STATUS_OK_AS_IS:
             default:
                 return;

--- a/src/test/java/com/bazaarvoice/jackson/rison/RootSeparatorTest.java
+++ b/src/test/java/com/bazaarvoice/jackson/rison/RootSeparatorTest.java
@@ -1,0 +1,52 @@
+package com.bazaarvoice.jackson.rison;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+public class RootSeparatorTest {
+
+    @Test
+    public void testDefault() throws IOException {
+        RisonFactory factory = new RisonFactory();
+        String string = writeObjects(factory, "hello", "world");
+        Assert.assertEquals(string, "hello world");
+    }
+
+    @Test
+    public void testNewline() throws IOException {
+        RisonFactory factory = new RisonFactory();
+        factory.setRootValueSeparator("\n");
+        String string = writeObjects(factory, "hello", "world");
+        Assert.assertEquals(string, "hello\nworld");
+    }
+
+    @Test
+    public void testNone() throws IOException {
+        RisonFactory factory = new RisonFactory();
+        factory.setRootValueSeparator(null);
+        String string = writeObjects(factory, "hello", "world");
+        Assert.assertEquals(string, "helloworld");
+    }
+
+    @Test
+    public void testComma() throws IOException {
+        RisonFactory factory = new RisonFactory();
+        factory.setRootValueSeparator(", ");
+        String string = writeObjects(factory, "hello", "world");
+        Assert.assertEquals(string, "hello, world");
+    }
+
+    private String writeObjects(RisonFactory factory, Object... objects) throws IOException {
+        StringWriter out = new StringWriter();
+        JsonGenerator gen = factory.createGenerator(out);
+        for (Object object : objects) {
+            gen.writeObject(object);
+        }
+        gen.close();
+        return out.toString();
+    }
+}

--- a/src/test/java/com/bazaarvoice/jackson/rison/VersionTest.java
+++ b/src/test/java/com/bazaarvoice/jackson/rison/VersionTest.java
@@ -15,15 +15,15 @@ public class VersionTest {
     public void testMapperVersions() throws IOException {
         RisonFactory factory = new RisonFactory();
         assertVersion(factory);
-        assertVersion(factory.createJsonGenerator(new ByteArrayOutputStream()));
-        assertVersion(factory.createJsonParser(new byte[0]));
+        assertVersion(factory.createGenerator(new ByteArrayOutputStream()));
+        assertVersion(factory.createParser(new byte[0]));
     }
 
     private void assertVersion(Versioned versioned) {
         Version version = versioned.version();
         assertFalse(version.isUknownVersion(), "Should find version information (got " + version + ")");
         assertEquals(version.getMajorVersion(), 2);
-        assertEquals(version.getMinorVersion(), 0);
+        assertEquals(version.getMinorVersion(), 1);
         assertEquals(version.getGroupId(), "com.bazaarvoice.jackson");
         assertEquals(version.getArtifactId(), "rison");
     }


### PR DESCRIPTION
Add support for RootValueSeparator.
