### PR TITLE
Make the project build with Jackson 2.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 Rison Parser and Generator for Jackson
 ======================================
 
-A plugin for the [Jackson streaming JSON processor v2.1.x] (http://wiki.fasterxml.com/JacksonHome) that adds
+A plugin for the [Jackson streaming JSON processor v2.6.x] (http://wiki.fasterxml.com/JacksonHome) that adds
 support for reading and writing JSON objects in the [Rison] (http://mjtemplate.org/examples/rison.html)
-serialization format.  Support for Jackson [v2.0.x] (https://github.com/bazaarvoice/rison/tree/rison-2.0.1)
+serialization format.  Support for Jackson [v2.1.x] (https://github.com/bazaarvoice/rison/tree/rison-2.1.1), [v2.0.x] (https://github.com/bazaarvoice/rison/tree/rison-2.0.1),
 and [v1.9.x] (https://github.com/bazaarvoice/rison/tree/rison-1.2) is also available.
 
 Rison expresses the exact same data structures as JSON, but is much more compact and readable than JSON
 when encoded in a URI.
 
-See http://mjtemplate.org/examples/rison.html for more information about Rison.
+See https://github.com/Nanonid/rison for more information about Rison.
 
 Usage
 -----

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.bazaarvoice.jackson</groupId>
     <artifactId>rison</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.6.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Rison data format</name>
@@ -34,7 +34,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jackson.version>2.1.3</jackson.version>
+        <jackson.version>2.6.3</jackson.version>
+
+        <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
+        <packageVersion.dir>com/bazaarvoice/jackson/rison</packageVersion.dir>
+        <packageVersion.package>${project.groupId}.json</packageVersion.package>
+        <packageVersion.template.input>src/main/java/${packageVersion.dir}/PackageVersion.java.in</packageVersion.template.input>
+        <packageVersion.template.output>${generatedSourcesDir}/${packageVersion.dir}/PackageVersion.java</packageVersion.template.output>
     </properties>
 
     <dependencies>
@@ -60,13 +66,6 @@
     </dependencies>
 
     <build>
-        <!-- Enable filtering to inject version into VERSION.txt. -->
-        <resources>
-            <resource>
-                <directory>${basedir}/src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <pluginManagement>
             <plugins>
                 <!-- Make sure we always turn all warnings on during compilation. -->
@@ -81,5 +80,59 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${generatedSourcesDir}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.1</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <file>${packageVersion.template.input}</file>
+                    <outputFile>${packageVersion.template.output}</outputFile>
+                    <replacements>
+                        <replacement>
+                            <token>@PACKAGE@</token>
+                            <value>${packageVersion.package}</value>
+                        </replacement>
+                        <replacement>
+                            <token>@PROJECT_VERSION@</token>
+                            <value>${project.version}</value>
+                        </replacement>
+                        <replacement>
+                            <token>@PROJECT_GROUP_ID@</token>
+                            <value>${project.groupId}</value>
+                        </replacement>
+                        <replacement>
+                            <token>@PROJECT_ARTIFACT_ID@</token>
+                            <value>${project.artifactId}</value>
+                        </replacement>
+                    </replacements>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/src/main/java/com/bazaarvoice/jackson/rison/ModuleVersion.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/ModuleVersion.java
@@ -1,7 +1,0 @@
-package com.bazaarvoice.jackson.rison;
-
-import com.fasterxml.jackson.core.util.VersionUtil;
-
-public class ModuleVersion extends VersionUtil {
-    public final static ModuleVersion instance = new ModuleVersion();
-}

--- a/src/main/java/com/bazaarvoice/jackson/rison/PackageVersion.java.in
+++ b/src/main/java/com/bazaarvoice/jackson/rison/PackageVersion.java.in
@@ -1,0 +1,18 @@
+package com.bazaarvoice.jackson.rison;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.util.VersionUtil;
+
+/**
+This class is generated programmatically by Maven.
+*/
+public class PackageVersion {
+
+    public static final Version INSTANCE =
+        VersionUtil.parseVersion("@PROJECT_VERSION@", "@PROJECT_GROUP_ID@", "@PROJECT_ARTIFACT_ID@");
+
+    public static Version version() {
+        return INSTANCE;
+    }
+
+}

--- a/src/main/java/com/bazaarvoice/jackson/rison/RisonFactory.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/RisonFactory.java
@@ -69,7 +69,7 @@ public class RisonFactory extends JsonFactory {
 
     @Override
     public Version version() {
-        return ModuleVersion.instance.version();
+        return PackageVersion.version();
     }
 
     //
@@ -126,6 +126,11 @@ public class RisonFactory extends JsonFactory {
         return (_risonGeneratorFeatures & f.getMask()) != 0;
     }
 
+    @Override
+    public boolean canUseCharArrays() {
+        return false;
+    }
+
     //
     // Internal factory methods
     //
@@ -146,21 +151,20 @@ public class RisonFactory extends JsonFactory {
     }
 
     @Deprecated
-    @Override
     protected RisonParser _createJsonParser(InputStream in, IOContext ctxt) throws IOException, JsonParseException {
         return _createJsonParser(new InputStreamReader(in, "UTF-8"), ctxt);
     }
 
     @Deprecated
-    @Override
     protected RisonParser _createJsonParser(Reader r, IOContext ctxt) throws IOException, JsonParseException {
         return new RisonParser(ctxt, _parserFeatures, _risonParserFeatures, r, _objectCodec,
-                _rootCharSymbols.makeChild(isEnabled(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES),
-                        isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES)));
+                    _rootCharSymbols.makeChild(
+                            (isEnabled(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES) ? JsonFactory.Feature.CANONICALIZE_FIELD_NAMES.getMask() : 0)
+                                    |
+                                        (isEnabled(JsonFactory.Feature.INTERN_FIELD_NAMES) ? JsonFactory.Feature.INTERN_FIELD_NAMES.getMask() : 0)));
     }
 
     @Deprecated
-    @Override
     protected RisonParser _createJsonParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException, JsonParseException {
         return _createJsonParser(new ByteArrayInputStream(data, offset, len), ctxt);
     }
@@ -171,7 +175,6 @@ public class RisonFactory extends JsonFactory {
     }
 
     @Deprecated
-    @Override
     protected RisonGenerator _createJsonGenerator(Writer out, IOContext ctxt) throws IOException {
         RisonGenerator gen = new RisonGenerator(ctxt, _generatorFeatures, _risonGeneratorFeatures, _objectCodec, out);
         SerializableString rootSep = _rootValueSeparator;
@@ -187,8 +190,8 @@ public class RisonFactory extends JsonFactory {
     }
 
     @Deprecated
-    @Override
     protected RisonGenerator _createUTF8JsonGenerator(OutputStream out, IOContext ctxt) throws IOException {
         return _createJsonGenerator(_createWriter(out, JsonEncoding.UTF8, ctxt), ctxt);
     }
+
 }

--- a/src/main/java/com/bazaarvoice/jackson/rison/RisonGenerator.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/RisonGenerator.java
@@ -147,7 +147,7 @@ public final class RisonGenerator
 
     @Override
     public Version version() {
-        return ModuleVersion.instance.version();
+        return PackageVersion.version();
     }
 
     /*

--- a/src/main/java/com/bazaarvoice/jackson/rison/RisonParser.java
+++ b/src/main/java/com/bazaarvoice/jackson/rison/RisonParser.java
@@ -31,6 +31,9 @@ import java.io.Writer;
 public class RisonParser
         extends ParserBase
 {
+
+    public static final char INT_APOSTROPHE = '\'';
+
     /**
      * Enumeration that defines all configurable features for Rison parsers.
      */
@@ -144,7 +147,7 @@ public class RisonParser
 
     @Override
     public Version version() {
-        return ModuleVersion.instance.version();
+        return PackageVersion.version();
     }
 
     /*
@@ -563,14 +566,14 @@ public class RisonParser
                 * and could be indicate by a more specific error message.
                 */
             case INT_0:
-            case INT_1:
-            case INT_2:
-            case INT_3:
-            case INT_4:
-            case INT_5:
-            case INT_6:
-            case INT_7:
-            case INT_8:
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
             case INT_9:
                 t = parseNumberText(i);
                 break;
@@ -584,13 +587,13 @@ public class RisonParser
                         }
                         t = JsonToken.START_ARRAY;
                         break;
-                    case INT_t:
+                    case 't':
                         t = JsonToken.VALUE_TRUE;
                         break;
-                    case INT_f:
+                    case 'f':
                         t = JsonToken.VALUE_FALSE;
                         break;
-                    case INT_n:
+                    case 'n':
                         t = JsonToken.VALUE_NULL;
                         break;
                     default:
@@ -834,7 +837,7 @@ public class RisonParser
             int fractLen = 0;
 
             // And then see if we get other parts
-            if (ch == INT_DECIMAL_POINT) { // yes, fraction
+            if (ch == '.') { // yes, fraction
                 fract_loop:
                 while (true) {
                     if (ptr >= inputLen) {

--- a/src/main/resources/com/bazaarvoice/jackson/rison/VERSION.txt
+++ b/src/main/resources/com/bazaarvoice/jackson/rison/VERSION.txt
@@ -1,3 +1,0 @@
-${project.version}
-${project.groupId}
-${project.artifactId}

--- a/src/test/java/com/bazaarvoice/jackson/rison/VersionTest.java
+++ b/src/test/java/com/bazaarvoice/jackson/rison/VersionTest.java
@@ -23,7 +23,7 @@ public class VersionTest {
         Version version = versioned.version();
         assertFalse(version.isUknownVersion(), "Should find version information (got " + version + ")");
         assertEquals(version.getMajorVersion(), 2);
-        assertEquals(version.getMinorVersion(), 1);
+        assertEquals(version.getMinorVersion(), 6);
         assertEquals(version.getGroupId(), "com.bazaarvoice.jackson");
         assertEquals(version.getArtifactId(), "rison");
     }


### PR DESCRIPTION
I've left the deprecated constructors present in `RisonFactory`. They no longer override any methods that are present in the superclass, so it might be time to remove them. In addition, there are some new factory methods that aren't yet overridden. I'll open another pull request for that work, if you'd like me to tackle it.
